### PR TITLE
Fixes #1, wrong context inside arrow functions.

### DIFF
--- a/ch02-intro-to-node/listing_211/index.js
+++ b/ch02-intro-to-node/listing_211/index.js
@@ -6,13 +6,13 @@ const channel = new events.EventEmitter();
 channel.clients = {};
 channel.subscriptions = {};
 channel.on('join', (id, client) => {
-  this.clients[id] = client;
-  this.subscriptions[id] = (senderId, message) => {
+  channel.clients[id] = client;
+  channel.subscriptions[id] = (senderId, message) => {
     if (id != senderId) {
-      this.clients[id].write(message);
+      channel.clients[id].write(message);
     }
   };
-  this.on('broadcast', this.subscriptions[id]);
+  channel.on('broadcast', channel.subscriptions[id]);
 });
 
 const server = net.createServer(client => {

--- a/ch02-intro-to-node/listing_212/index.js
+++ b/ch02-intro-to-node/listing_212/index.js
@@ -6,17 +6,17 @@ const channel = new events.EventEmitter();
 channel.clients = {};
 channel.subscriptions = {};
 channel.on('join', (id, client) => {
-  this.clients[id] = client;
-  this.subscriptions[id] = (senderId, message) => {
+  channel.clients[id] = client;
+  channel.subscriptions[id] = (senderId, message) => {
     if (id != senderId) {
-      this.clients[id].write(message);
+      channel.clients[id].write(message);
     }
   };
-  this.on('broadcast', this.subscriptions[id]);
+  channel.on('broadcast', channel.subscriptions[id]);
 });
 
 channel.on('leave', id => {
-  channel.removeListener('broadcast', this.subscriptions[id]);
+  channel.removeListener('broadcast', channel.subscriptions[id]);
   channel.emit('broadcast', id, id + ' has left.\n');
 });
 


### PR DESCRIPTION
According to https://nodejs.org/api/all.html#events_passing_arguments_and_this_to_listeners,
`this` keyword no longer references the `EventEmitter` instance. Now `channel` is used directly.