### PR TITLE
Fix bind usage

### DIFF
--- a/ch12-desktop/electron-quick-start-print/app/request_headers.jsx
+++ b/ch12-desktop/electron-quick-start-print/app/request_headers.jsx
@@ -6,6 +6,8 @@ class AddHeader extends React.Component {
   constructor(props) {
     super(props);
     this.state = { name: null, value: null };
+    this.handleChange = this.handleChange.bind(this);
+    this.handleAdd = this.handleAdd.bind(this);
   }
 
   handleChange(e) {
@@ -27,13 +29,10 @@ class AddHeader extends React.Component {
   }
 
   render() {
-    const handleChange = this.handleChange.bind(this);
-    const handleAdd = this.handleAdd.bind(this);
-
     return (
       <tr className="add">
-        <td className="name"><input name="name" type="text" value={this.state.name} placeholder="Name" onChange={handleChange} /> </td>
-        <td className="value"><input name="value" type="text" value={this.state.value} placeholder="Value" onChange={handleChange} /> <a href="#" className="round-btn" onClick={handleAdd}>+</a></td>
+        <td className="name"><input name="name" type="text" value={this.state.name} placeholder="Name" onChange={this.handleChange} /> </td>
+        <td className="value"><input name="value" type="text" value={this.state.value} placeholder="Value" onChange={this.handleChange} /> <a href="#" className="round-btn" onClick={this.handleAdd}>+</a></td>
       </tr>
     );
   }

--- a/ch12-desktop/electron-quick-start-print/app/response.jsx
+++ b/ch12-desktop/electron-quick-start-print/app/response.jsx
@@ -12,14 +12,15 @@ class Response extends React.Component {
       result: {},
       tab: 'body'
     };
+    this.handleResult = this.handleResult.bind(this);
   }
 
   componentWillUnmount() {
-    Events.removeListener('result', this.handleResult.bind(this));
+    Events.removeListener('result', this.handleResult);
   }
 
   componentDidMount() {
-    Events.addListener('result', this.handleResult.bind(this));
+    Events.addListener('result', this.handleResult);
   }
 
   handleResult(result) {

--- a/ch12-desktop/electron-quick-start-print/app/response.jsx
+++ b/ch12-desktop/electron-quick-start-print/app/response.jsx
@@ -13,6 +13,7 @@ class Response extends React.Component {
       tab: 'body'
     };
     this.handleResult = this.handleResult.bind(this);
+    this.handleSelectTab = this.handleSelectTab.bind(this);
   }
 
   componentWillUnmount() {
@@ -48,7 +49,6 @@ class Response extends React.Component {
   }
 
   render() {
-    const handleSelectTab = this.handleSelectTab.bind(this);
     const result = this.state.result;
     const highlightLanguage = this.getHighlightLanguage();
     const tabClasses = {
@@ -75,10 +75,10 @@ class Response extends React.Component {
             <div className="results">
               <ul className="nav">
                 <li className={tabClasses.body}>
-                  <a data-tab='body' onClick={handleSelectTab}>Body</a>
+                  <a data-tab='body' onClick={this.handleSelectTab}>Body</a>
                 </li>
                 <li className={tabClasses.errors}>
-                  <a data-tab='errors' href="#" onClick={handleSelectTab}>Errors</a>
+                  <a data-tab='errors' href="#" onClick={this.handleSelectTab}>Errors</a>
                 </li>
               </ul>
               <div className="raw" id="raw" style={this.state.tab === 'body' ? null : {display: 'none'}}><Highlight className={highlightLanguage}>{result.raw}</Highlight></div>

--- a/ch12-desktop/electron-quick-start/app/request_headers.jsx
+++ b/ch12-desktop/electron-quick-start/app/request_headers.jsx
@@ -6,6 +6,8 @@ class AddHeader extends React.Component {
   constructor(props) {
     super(props);
     this.state = { name: null, value: null };
+    this.handleChange = this.handleChange.bind(this);
+    this.handleAdd = this.handleAdd.bind(this);
   }
 
   handleChange(e) {
@@ -27,13 +29,10 @@ class AddHeader extends React.Component {
   }
 
   render() {
-    const handleChange = this.handleChange.bind(this);
-    const handleAdd = this.handleAdd.bind(this);
-
     return (
       <tr className="add">
-        <td className="name"><input name="name" type="text" value={this.state.name} placeholder="Name" onChange={handleChange} /> </td>
-        <td className="value"><input name="value" type="text" value={this.state.value} placeholder="Value" onChange={handleChange} /> <a href="#" className="round-btn" onClick={handleAdd}>+</a></td>
+        <td className="name"><input name="name" type="text" value={this.state.name} placeholder="Name" onChange={this.handleChange} /> </td>
+        <td className="value"><input name="value" type="text" value={this.state.value} placeholder="Value" onChange={this.handleChange} /> <a href="#" className="round-btn" onClick={this.handleAdd}>+</a></td>
       </tr>
     );
   }

--- a/ch12-desktop/electron-quick-start/app/response.jsx
+++ b/ch12-desktop/electron-quick-start/app/response.jsx
@@ -12,14 +12,15 @@ class Response extends React.Component {
       result: {},
       tab: 'body'
     };
+    this.handleResult = this.handleResult.bind(this);
   }
 
   componentWillUnmount() {
-    Events.removeListener('result', this.handleResult.bind(this));
+    Events.removeListener('result', this.handleResult);
   }
 
   componentDidMount() {
-    Events.addListener('result', this.handleResult.bind(this));
+    Events.addListener('result', this.handleResult);
   }
 
   handleResult(result) {

--- a/ch12-desktop/electron-quick-start/app/response.jsx
+++ b/ch12-desktop/electron-quick-start/app/response.jsx
@@ -13,6 +13,7 @@ class Response extends React.Component {
       tab: 'body'
     };
     this.handleResult = this.handleResult.bind(this);
+    this.handleSelectTab = this.handleSelectTab.bind(this);
   }
 
   componentWillUnmount() {
@@ -48,7 +49,6 @@ class Response extends React.Component {
   }
 
   render() {
-    const handleSelectTab = this.handleSelectTab.bind(this);
     const result = this.state.result;
     const highlightLanguage = this.getHighlightLanguage();
     const tabClasses = {
@@ -75,10 +75,10 @@ class Response extends React.Component {
             <div className="results">
               <ul className="nav">
                 <li className={tabClasses.body}>
-                  <a data-tab='body' onClick={handleSelectTab}>Body</a>
+                  <a data-tab='body' onClick={this.handleSelectTab}>Body</a>
                 </li>
                 <li className={tabClasses.errors}>
-                  <a data-tab='errors' href="#" onClick={handleSelectTab}>Errors</a>
+                  <a data-tab='errors' href="#" onClick={this.handleSelectTab}>Errors</a>
                 </li>
               </ul>
               <div className="raw" id="raw" style={this.state.tab === 'body' ? null : {display: 'none'}}><Highlight className={highlightLanguage}>{result.raw}</Highlight></div>


### PR DESCRIPTION
Greetings,

This PR address the usage of bind in render and with listeners.
bind returns a new function every time its called, 
so using it in render would cause performance degradation due to the creation of a new function every time and the subsequent unnecessary renders of child components
Also, using it with listers causes memory leaks; as a result of creating a new function each time, the lister will not be able to remove the existing listener using the new reference.

Best Regards,
Ahmed